### PR TITLE
Fixed teddycloud upload in recursive mode

### DIFF
--- a/audio2tonie.sh
+++ b/audio2tonie.sh
@@ -180,8 +180,9 @@ process_recursive() {
         local count
         count=$(find "$d" -maxdepth 1 -type f | wc -l)
         transcode_files "$d" "$SOURCE/$OUTPUT_FILE" "$count"
-        if [[ -n "${TEDDYCLOUD_IP:-}" ]]; then
-            upload_to_teddycloud "$SOURCE/$OUTPUT_FILE"
+        if [[ -n "${TEDDYCLOUD_URI:-}" ]]; then
+            normalized_uri=$(normalize_teddycloud_uri "$TEDDYCLOUD_URI")
+            upload_to_teddycloud "$SOURCE/$OUTPUT_FILE" "$normalized_uri" "${TEDDYCLOUD_PATH:-/}"
         fi
         echo "$SEPARATOR"
     done


### PR DESCRIPTION
After a fresh docker pull the teddycloud upload failed when using recursive mode (-r).  
Fixed the check for TEDDYCLOUD_URL (was TEDDYCLOUD_IP) and added upload path.  

PS: Great work on this tool, it really saves time and the kids enjoy it